### PR TITLE
v0.4.0: side panel, tabbed popup, batch opening, and new opener settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@ node_modules/
 .claude
 
 # Internal
-RESEARCH.md
+research/
 PUBLISH.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-04
+
+### Added
+- **Side panel** — the full BulkyURLs UI now runs in Chrome's side panel (`sidePanel` API). Open it with the **Open Sidebar** button in the popup; it stays open while you browse
+- **Open in New Tab** button — run the UI in a full browser tab
+- **Tabbed popup** — the popup is reorganized into **URLs** and **Settings** tabs with a card-based layout
+- **Batch opening** — configurable *URLs per batch* (1–20) and *delay between batches* (0–100s) with sliders and steppers; opening runs in the background service worker so it continues after the popup closes
+- **Undo / Redo** for the URL textarea (programmatic changes and typing)
+- **Copy** button — copy the list to the clipboard
+- **Tools menu** — URLs from Tabs / from Selection, Remove Duplicates, and CSV import/export moved into a dropdown
+- **Settings tab** with new opening options:
+  - Convert non-URLs to search queries (non-URL lines open as Google searches)
+  - Open URLs in random order / reverse order
+  - Open each batch in a new window
+  - Wait for tab to load before opening the next URL
+  - Remove opened URLs from input
+  - Auto-close tabs after a configurable number of seconds
+  - URL limit (open only the first N URLs; 0 = no limit)
+  - Reset Defaults
+- **Saved Lists redesign** — lists render as rows with URL counts, one-click load, and inline delete; “+ New” reveals the save form
+- Live **“N valid”** count badge on the URL textarea
+
+### Changed
+- The pre-0.4 popup delay setting is migrated to the new opener settings on first run
+- All opener settings persist in `chrome.storage.local` under `opener_settings`
+
 ### Repo / Tooling
 - Added `.github/workflows/release.yml` — pushing a `v*` tag matching `manifest.json`'s version builds the extension zip, creates a GitHub Release with notes pulled from this changelog, and uploads/publishes to the Chrome Web Store if environment variables and secrets are configured
-- No changes to the extension bundle itself; manifest version is unchanged
 
 ## [0.3.0] - 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -9,31 +9,60 @@ BulkyURLs is a Chrome extension (Manifest V3) for managing large numbers of URLs
 ### Drag-Select Links
 Hold **Shift** + left-click-drag over any area of a page. A dotted selection box appears, and every link it touches is highlighted in red. The extension badge on the toolbar shows the live count of selected links. When you release the mouse, the selection is captured and the badge updates to the final count.
 
-### Popup Tools
-Open the popup (click the BulkyURLs toolbar icon) after making a selection — the selected URLs appear in the textarea automatically. A live counter above the textarea shows how many URLs are currently detected.
+### Popup, Side Panel & Full Tab
+The same UI runs in three places:
+
+- **Popup** — click the BulkyURLs toolbar icon. After a drag selection, the selected URLs appear in the textarea automatically.
+- **Side panel** — click **Open Sidebar** in the popup. The panel docks beside the page and stays open while you browse.
+- **Full tab** — click **Open in New Tab** for a roomier view.
+
+The UI is split into two tabs: **URLs** (the list, batch settings, saved lists) and **Settings** (opening options).
+
+#### URLs tab
+
+A live **“N valid”** badge above the textarea shows how many URLs are currently detected.
 
 | Control | What it does |
 |---|---|
-| **URLs from Text** | Strips non-URL text from the textarea, leaving only valid URLs |
-| **URLs from Tabs** | Fills the textarea with the URLs of every open tab |
-| **URLs from Selection** | Re-fetches the current drag selection into the textarea |
-| **Remove Duplicates** | Removes duplicate lines from the textarea, keeping first-seen order |
-| **Open in New Tabs** | Opens every URL in the textarea as background tabs in the current window |
-| **Open in New Window** | Opens every URL in the textarea in a brand-new window |
-| **Delay** | Seconds to wait between each tab opening (prevents browser overload on large lists; persisted across sessions) |
+| **Undo / Redo** | Steps back/forward through textarea changes (typing and button actions) |
+| **Copy** | Copies the textarea contents to the clipboard |
+| **Extract URLs** | Strips non-URL text from the textarea, leaving only valid URLs |
 | **Clear** | Empties the textarea |
-| **Export CSV** | Downloads the current textarea URLs as a `bulkyurls-export.csv` file |
-| **Import CSV** | Opens a file picker; parses any `.csv` file and loads the URLs it contains into the textarea |
+| **Tools ▾ → URLs from Tabs** | Fills the textarea with the URLs of every open tab |
+| **Tools ▾ → URLs from Selection** | Re-fetches the current drag selection into the textarea |
+| **Tools ▾ → Remove Duplicates** | Removes duplicate lines from the textarea, keeping first-seen order |
+| **Tools ▾ → Import / Export CSV** | CSV round-trip (see CSV Format below) |
+| **Open in Tabs** | Opens the URLs as background tabs in the current window, batch by batch |
+| **New Window** | Opens the URLs in a brand-new window, batch by batch |
 
-Opening is delegated to the background service worker, so a delayed batch keeps opening even after the popup closes.
+**Batch Settings** control how opening happens:
+
+- **URLs per batch** (1–20) — how many tabs open at once.
+- **Delay (seconds)** (0–100) — pause between batches. Use a smaller batch size and a longer delay to avoid triggering browser security restrictions on large lists.
+
+Opening is delegated to the background service worker, so a batched/delayed run keeps opening even after the popup closes. Batch size and delay are persisted across sessions.
+
+#### Settings tab
+
+| Option | What it does |
+|---|---|
+| **Convert non-URLs to search queries** | Lines that aren't URLs open as Google searches instead of being dropped |
+| **Open URLs in random order** | Shuffles the list before opening |
+| **Open URLs in reverse order** | Opens the list bottom-to-top |
+| **Open each batch in a new window** | Every batch gets its own browser window |
+| **Wait for tab to load before opening next URL** | Each tab must finish loading before the next opens |
+| **Remove opened URLs from input** | Opened URLs are deleted from the textarea when you click Open |
+| **Auto-close tabs after N s** | Opened tabs close themselves after the chosen number of seconds |
+| **URL Limit** | Open only the first N URLs (0 = no limit) |
+| **Reset Defaults** | Restores all opener settings |
 
 ### Saved Lists
 Save the current textarea contents under a custom name and reload it any time — handy for recurring link sets (daily reading lists, QA test URLs, etc.). Lists are stored locally via `chrome.storage.local`; nothing leaves your machine.
 
-- Type a name and click **Save** to store the current URLs.
-- Pick a list from the dropdown to load it into the textarea.
-- Click **Delete** to remove the selected list.
-- To update an existing list, select it in the dropdown and click **Save** with the name box empty.
+- Click **+ New**, type a name, and click **Save** to store the current URLs.
+- Click a list's name to load it into the textarea; each row shows its URL count.
+- Click **×** on a row to delete that list.
+- To update an existing list, save again under the same name.
 
 ### CSV Format
 
@@ -63,7 +92,7 @@ Right-click the toolbar icon → **Options** (or open via `chrome://extensions`)
 
 ## Requirements
 
-- **Google Chrome** 102+ (Manifest V3, File System Access API)
+- **Google Chrome** 114+ (Manifest V3, File System Access API, Side Panel API)
 - Chromium-based browsers (Edge, Brave, etc.) should also work
 
 ---
@@ -85,7 +114,8 @@ Right-click the toolbar icon → **Options** (or open via `chrome://extensions`)
 3. The links highlight red; the toolbar badge shows the count.
 4. Release the mouse — the selection is captured.
 5. Click the BulkyURLs icon — the selected URLs appear in the popup textarea.
-6. Use **Open in New Tabs** (or **Open in New Window**) to open them all, or copy the text to use elsewhere.
+6. Use **Open in Tabs** (or **New Window**) to open them all, or **Copy** the list to use elsewhere.
+7. Prefer a persistent view? Click **Open Sidebar** to dock the same UI in Chrome's side panel.
 
 ---
 
@@ -95,6 +125,7 @@ Right-click the toolbar icon → **Options** (or open via `chrome://extensions`)
 bulkyurls/
 ├── manifest.json              # MV3 manifest
 ├── popup.html                 # Popup UI
+├── sidepanel.html             # Same UI for Chrome's side panel / full tab
 ├── options.html               # Options page
 ├── csv.html                   # CSV import/export dialog
 ├── css/

--- a/css/popup.css
+++ b/css/popup.css
@@ -8,6 +8,7 @@
   --color-border: #dbeafe;
   --color-focus: #93c5fd;
   --color-info-bg: #eff6ff;
+  --color-accent: #2563eb;
 
   /* Colors — text */
   --color-text: #1e293b;
@@ -19,6 +20,7 @@
 
   /* Colors — success */
   --color-success: #16a34a;
+  --color-success-bg: #dcfce7;
 
   /* Typography */
   --font-family: "Segoe UI", system-ui, sans-serif;
@@ -43,61 +45,173 @@
   --space-lg: 1rem;
 
   /* Buttons */
-  --btn-width: 180px;
   --btn-height: 30px;
 
   /* Transitions */
   --transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   background-color: var(--color-bg);
   padding: var(--space-md);
   width: 400px;
+  margin: 0;
+  font-family: var(--font-family);
+  color: var(--color-text);
 }
 
-.textarea-wrapper {
+/* Side panel / full tab: fill the available width instead of popup's fixed 400px */
+body.sidepanel {
+  width: auto;
+  min-width: 320px;
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+/* ------- Header ------- */
+
+.app-header {
   display: flex;
-  flex-direction: column;
+  align-items: baseline;
+  gap: var(--space-md);
   margin-bottom: var(--space-sm);
 }
 
-.textarea-toolbar {
+.app-header h1 {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.25rem;
+  gap: var(--space-md);
+  font-size: 1.25rem;
+  margin: 0.2rem 0;
 }
 
-.url-count {
-  font-family: var(--font-family);
+.app-version {
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
-.textarea-wrapper #clear {
+/* ------- Sidebar / new-tab launchers ------- */
+
+.launch-row {
+  display: flex;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.launch-row .button.launch {
+  flex: 1;
   width: auto;
-  padding: 0 14px;
-  height: 24px;
-  font-size: var(--font-size-xs);
   margin: 0;
 }
 
-.textarea-wrapper textarea {
-  width: 100%;
-  box-sizing: border-box;
+/* ------- Tab bar ------- */
+
+.tab-bar {
+  display: flex;
+  gap: var(--space-lg);
+  border-bottom: 1px solid var(--color-border);
+  margin-bottom: var(--space-md);
 }
 
+.tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: var(--space-sm) var(--space-xs);
+  font-family: var(--font-family);
+  font-size: var(--font-size-base);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.tab:hover {
+  color: var(--color-text);
+}
+
+.tab.active {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+  font-weight: 600;
+}
+
+.tab-panel {
+  display: none;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+/* ------- Cards ------- */
+
+.card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-sm);
+}
+
+.card-title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+}
+
+.count-badge {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  background-color: var(--color-info-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+
+.count-badge.valid {
+  color: var(--color-success);
+  background-color: var(--color-success-bg);
+  border-color: var(--color-success);
+}
+
+.sub-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background-color: var(--color-bg);
+  padding: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.sub-card-title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  margin: 0 0 var(--space-sm);
+}
+
+/* ------- Textarea ------- */
+
 #userInput {
+  width: 100%;
+  box-sizing: border-box;
   resize: vertical;
   font-family: var(--font-family);
-  height: 7rem;
+  height: 8rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   outline: none;
-  font-size: var(--font-size-lg);
-  padding-left: var(--space-md);
-  padding-top: var(--space-sm);
+  font-size: var(--font-size-base);
+  padding: var(--space-sm) var(--space-md);
 }
 
 #userInput:focus {
@@ -105,12 +219,111 @@ body {
   box-shadow: var(--shadow-md);
 }
 
-.button-group {
+/* ------- Chip toolbar ------- */
+
+.chip-row {
   display: flex;
-  align-content: center;
-  justify-content: space-between;
   flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-sm);
+  align-items: center;
 }
+
+.chip {
+  background-color: var(--color-info-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family);
+  font-size: var(--font-size-xs);
+  color: var(--color-text);
+  padding: 3px 8px;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.chip:hover {
+  background-color: var(--color-border);
+}
+
+.chip:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.chip.danger {
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+  background-color: var(--color-surface);
+}
+
+.chip.danger:hover {
+  background-color: var(--color-danger-bg);
+}
+
+/* ------- Tools dropdown ------- */
+
+.tools-wrap {
+  position: relative;
+  margin-left: auto;
+}
+
+.tools-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 2px);
+  z-index: 10;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  min-width: 170px;
+  padding: var(--space-xs);
+}
+
+.tools-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  padding: 5px 8px;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.tools-item:hover {
+  background-color: var(--color-hover);
+}
+
+/* ------- Action row (open buttons) ------- */
+
+.action-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-top: var(--space-md);
+}
+
+.summary-badges {
+  display: flex;
+  gap: var(--space-xs);
+  margin-right: auto;
+}
+
+.mini-badge {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 1px 6px;
+}
+
+/* ------- Buttons ------- */
 
 .button {
   background-color: var(--color-surface);
@@ -124,7 +337,6 @@ body {
   font-family: var(--font-family);
   font-size: var(--font-size-sm);
   padding: 0 10px 0 11px;
-  margin: var(--space-xs);
   position: relative;
   text-align: center;
   text-decoration: none;
@@ -132,7 +344,6 @@ body {
   -webkit-user-select: none;
   touch-action: manipulation;
   vertical-align: middle;
-  width: var(--btn-width);
   height: var(--btn-height);
   transition: var(--transition);
 }
@@ -147,15 +358,6 @@ body {
   outline: 0;
 }
 
-.button.clear {
-  border: 1px solid var(--color-danger);
-  color: var(--color-danger);
-}
-
-.clear:hover {
-  background-color: var(--color-danger-bg);
-}
-
 .button.primary {
   background-color: var(--color-info-bg);
   border-color: var(--color-focus);
@@ -167,60 +369,156 @@ body {
 }
 
 .button.small {
-  width: auto;
-  height: 26px;
-  padding: 0 12px;
+  height: 24px;
+  padding: 0 10px;
   font-size: var(--font-size-xs);
 }
 
-.open-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  margin-top: var(--space-sm);
-}
-
-.open-row .button {
-  flex: 1;
-  width: auto;
-}
-
-.delay-control {
-  font-family: var(--font-family);
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
+.open-btn {
   white-space: nowrap;
-  display: flex;
-  align-items: center;
-  gap: 3px;
 }
 
-.delay-control input {
-  width: 42px;
+/* ------- Sliders / steppers ------- */
+
+.slider-group {
+  margin-bottom: var(--space-md);
+}
+
+.slider-label-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-xs);
+}
+
+.slider-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+}
+
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.stepper-btn {
+  width: 22px;
   height: 22px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  font-size: var(--font-size-xs);
-  padding: 0 4px;
-  box-sizing: border-box;
+  background-color: var(--color-surface);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  line-height: 1;
+  transition: var(--transition);
 }
 
-.delay-control input:focus {
+.stepper-btn:hover {
+  background-color: var(--color-hover);
+}
+
+.stepper input[type="number"],
+.inline-num {
+  width: 44px;
+  height: 22px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-family);
+  font-size: var(--font-size-xs);
+  text-align: center;
+  padding: 0 2px;
+  box-sizing: border-box;
+  background-color: var(--color-info-bg);
+  color: var(--color-text);
+}
+
+.stepper input[type="number"]:focus,
+.inline-num:focus {
   border-color: var(--color-focus);
   outline: 0;
 }
 
-.lists-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-  margin-top: var(--space-md);
-  padding-top: var(--space-sm);
-  border-top: 1px solid var(--color-border);
+input[type="range"] {
+  width: 100%;
+  accent-color: var(--color-accent);
+  margin: 2px 0;
 }
 
-.lists-row select,
-.lists-row input[type="text"] {
+.slider-scale {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.slider-hint {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin: var(--space-xs) 0 0;
+}
+
+.pro-tip {
+  font-size: var(--font-size-xs);
+  color: var(--color-accent);
+  background-color: var(--color-info-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm) var(--space-md);
+  margin: 0;
+}
+
+/* ------- Settings checkboxes ------- */
+
+.check-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  padding: 3px 0;
+  cursor: pointer;
+}
+
+.check-row input[type="checkbox"] {
+  accent-color: var(--color-accent);
+  margin: 0;
+}
+
+.check-row .inline-num {
+  width: 50px;
+}
+
+.limit-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.limit-row input[type="range"] {
+  flex: 1;
+}
+
+.limit-row .slider-hint {
+  margin: 0;
+  white-space: nowrap;
+}
+
+.settings-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ------- Saved lists ------- */
+
+.new-list-row {
+  display: flex;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-sm);
+}
+
+.new-list-row input[type="text"] {
   flex: 1;
   min-width: 0;
   height: 26px;
@@ -228,41 +526,90 @@ body {
   border-radius: var(--radius-sm);
   font-family: var(--font-family);
   font-size: var(--font-size-xs);
-  padding: 0 4px;
+  padding: 0 6px;
   background-color: var(--color-surface);
   color: var(--color-text);
   box-sizing: border-box;
 }
 
-.lists-row select:focus,
-.lists-row input[type="text"]:focus {
+.new-list-row input[type="text"]:focus {
   border-color: var(--color-focus);
   outline: 0;
 }
 
-.list-status {
+.saved-lists {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.saved-list-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 3px 6px;
+}
+
+.saved-list-name {
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  text-align: left;
   font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 2px 0;
+}
+
+.saved-list-name:hover {
+  color: var(--color-accent);
+}
+
+.saved-list-count {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.saved-list-delete {
+  background: none;
+  border: none;
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  padding: 0 4px;
+  border-radius: var(--radius-sm);
+  transition: var(--transition);
+}
+
+.saved-list-delete:hover {
+  background-color: var(--color-danger-bg);
+}
+
+.empty-note {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  font-style: italic;
+  text-align: center;
+  margin: var(--space-sm) 0;
+}
+
+.list-status {
   font-size: var(--font-size-xs);
   color: var(--color-success);
   min-height: 1.2em;
   margin-top: 2px;
 }
 
-.information-text__wrapper {
-  justify-content: end;
-  display: block;
-  margin-left: var(--space-sm);
-}
-
-.information-text__wrapper > p {
-  color: var(--color-text);
-}
-
-.information-text__header {
-  font-size: var(--font-size-base);
-}
-
-/* CSV dialog styles (used by csv.html) */
+/* ------- CSV dialog styles (used by csv.html) ------- */
 
 .csv-body {
   min-width: 380px;
@@ -327,6 +674,16 @@ body {
   flex: 1;
 }
 
-section {
+.button.clear {
+  border: 1px solid var(--color-danger);
+  color: var(--color-danger);
+}
+
+.button.clear:hover {
+  background-color: var(--color-danger-bg);
+}
+
+/* csv.html sections start hidden; csv.js reveals the one matching ?mode= */
+section:not(.tab-panel) {
   display: none;
 }

--- a/js/background/background.js
+++ b/js/background/background.js
@@ -94,6 +94,111 @@ function openTab(urls, delay, windowId, tabIndex, closeDelay) {
   });
 }
 
+// ------- Bulk opening for the popup / side panel -------
+
+function sleep(seconds) {
+  return new Promise(function(resolve) { setTimeout(resolve, seconds * 1000); });
+}
+
+function shuffle(arr) {
+  for (var i = arr.length - 1; i > 0; i--) {
+    var j = Math.floor(Math.random() * (i + 1));
+    var tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+  return arr;
+}
+
+function createTab(props) {
+  return new Promise(function(resolve) { chrome.tabs.create(props, resolve); });
+}
+
+function createWindow(props) {
+  return new Promise(function(resolve) { chrome.windows.create(props, resolve); });
+}
+
+// Resolves when the tab reaches status "complete" (or after a 30s safety timeout,
+// so a hung page never stalls the rest of the batch).
+function waitForTabLoad(tabId) {
+  return new Promise(function(resolve) {
+    var timer = setTimeout(done, 30000);
+    function done() {
+      clearTimeout(timer);
+      chrome.tabs.onUpdated.removeListener(listener);
+      resolve();
+    }
+    function listener(updatedTabId, changeInfo) {
+      if (updatedTabId === tabId && changeInfo.status === "complete") done();
+    }
+    chrome.tabs.onUpdated.addListener(listener);
+    // The tab may already be done loading by the time the listener attaches
+    chrome.tabs.get(tabId, function(tab) {
+      if (!chrome.runtime.lastError && tab && tab.status === "complete") done();
+    });
+  });
+}
+
+function scheduleClose(tabId, seconds) {
+  setTimeout(function() {
+    chrome.tabs.remove(tabId, function() { void chrome.runtime.lastError; });
+  }, seconds * 1000);
+}
+
+// Opens urls in batches according to the popup's opener settings.
+// mode: "tabs" (current window) or "win" (one new window, unless windowPerBatch).
+async function openBulk(urls, mode, o) {
+  urls = urls.slice();
+  if (urls.length === 0) return;
+  if (o.randomOrder) shuffle(urls);
+  if (o.reverseOrder) urls.reverse();
+  if (o.urlLimit > 0) urls = urls.slice(0, o.urlLimit);
+
+  var batchSize = Math.max(1, parseInt(o.batchSize, 10) || 1);
+  var delay = Math.max(0, parseFloat(o.delay) || 0);
+  var closeSecs = (o.autoClose && o.autoCloseSecs > 0) ? o.autoCloseSecs : 0;
+
+  var targetWindowId = null;
+  if (mode === "win" && !o.windowPerBatch) {
+    var first = urls.shift();
+    var win = await createWindow({ url: first });
+    targetWindowId = win.id;
+    if (closeSecs) scheduleClose(win.tabs[0].id, closeSecs);
+    if (o.waitForLoad) await waitForTabLoad(win.tabs[0].id);
+    if (urls.length === 0) return;
+  }
+
+  var batches = [];
+  for (var i = 0; i < urls.length; i += batchSize) {
+    batches.push(urls.slice(i, i + batchSize));
+  }
+
+  for (var b = 0; b < batches.length; b++) {
+    var batch = batches[b];
+    var batchWindowId = targetWindowId;
+
+    if (o.windowPerBatch) {
+      var newWin = await createWindow({ url: batch[0] });
+      batchWindowId = newWin.id;
+      if (closeSecs) scheduleClose(newWin.tabs[0].id, closeSecs);
+      if (o.waitForLoad) await waitForTabLoad(newWin.tabs[0].id);
+      batch = batch.slice(1);
+    }
+
+    for (var t = 0; t < batch.length; t++) {
+      var props = { url: batch[t], active: false };
+      if (batchWindowId != null) props.windowId = batchWindowId;
+      var tab = await createTab(props);
+      if (closeSecs) scheduleClose(tab.id, closeSecs);
+      if (o.waitForLoad) await waitForTabLoad(tab.id);
+    }
+
+    if (delay > 0 && b < batches.length - 1) {
+      await sleep(delay);
+    }
+  }
+}
+
 function uniqueURLs(arr) {
   var a = [];
   var l = arr.length;
@@ -159,21 +264,11 @@ function handleRequests(request, sender, sendResponse) {
 
       break;
 
-    // Popup "Open in New Tabs / New Window" — runs here so delayed opening
+    // Popup "Open in Tabs / New Window" — runs here so batched/delayed opening
     // continues after the popup closes.
     case "open_urls":
-      var pending = request.urls.map(function(u) { return { url: u }; });
-      if (pending.length === 0) break;
-      var popupDelay = request.delay || 0;
-      if (request.mode === "win") {
-        chrome.windows.create({ url: pending.shift().url }, function(win) {
-          if (pending.length > 0) {
-            openTab(pending, popupDelay, win.id, null, 0);
-          }
-        });
-      } else {
-        openTab(pending, popupDelay, null, null, 0);
-      }
+      openBulk(request.urls, request.mode, request.options || {})
+        .catch(function(e) { console.error("BulkyURLs: bulk open failed", e); });
       break;
 
     case "init":

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,10 +1,176 @@
 document.addEventListener('DOMContentLoaded', function() {
   var userInput = document.getElementById('userInput');
   var urlCount = document.getElementById('urlCount');
-  var delayInput = document.getElementById('delayInput');
   var listName = document.getElementById('listName');
-  var savedLists = document.getElementById('savedLists');
   var listStatus = document.getElementById('listStatus');
+  var savedListsContainer = document.getElementById('savedListsContainer');
+  var batchSlider = document.getElementById('batchSize');
+  var batchNum = document.getElementById('batchSizeNum');
+  var delaySlider = document.getElementById('delaySlider');
+  var delayNum = document.getElementById('delayNum');
+  var batchBadge = document.getElementById('batchBadge');
+  var delayBadge = document.getElementById('delayBadge');
+  var toolsMenu = document.getElementById('toolsMenu');
+  var undoBtn = document.getElementById('undo');
+  var redoBtn = document.getElementById('redo');
+
+  var isSidePanel = document.body.classList.contains('sidepanel');
+
+  document.getElementById('appVersion').textContent = 'v' + chrome.runtime.getManifest().version;
+
+  // ------- Opener settings (persisted as one object) -------
+
+  var DEFAULT_SETTINGS = {
+    batchSize: 1,
+    delay: 0,
+    searchQueries: false,
+    randomOrder: false,
+    reverseOrder: false,
+    windowPerBatch: false,
+    waitForLoad: false,
+    removeOpened: false,
+    autoClose: false,
+    autoCloseSecs: 10,
+    urlLimit: 0
+  };
+
+  var settings = Object.assign({}, DEFAULT_SETTINGS);
+
+  var optionInputs = {
+    searchQueries: document.getElementById('optSearchQueries'),
+    randomOrder: document.getElementById('optRandomOrder'),
+    reverseOrder: document.getElementById('optReverseOrder'),
+    windowPerBatch: document.getElementById('optWindowPerBatch'),
+    waitForLoad: document.getElementById('optWaitForLoad'),
+    removeOpened: document.getElementById('optRemoveOpened'),
+    autoClose: document.getElementById('optAutoClose')
+  };
+  var autoCloseSecs = document.getElementById('optAutoCloseSecs');
+  var limitSlider = document.getElementById('optLimit');
+  var limitNum = document.getElementById('optLimitNum');
+  var limitHint = document.getElementById('limitHint');
+  var limitDesc = document.getElementById('limitDesc');
+
+  function saveSettings() {
+    chrome.storage.local.set({ opener_settings: settings });
+  }
+
+  function renderSettings() {
+    batchSlider.value = settings.batchSize;
+    batchNum.value = settings.batchSize;
+    delaySlider.value = settings.delay;
+    delayNum.value = settings.delay;
+    batchBadge.textContent = settings.batchSize + '/batch';
+    delayBadge.textContent = settings.delay + 's';
+    Object.keys(optionInputs).forEach(function(key) {
+      optionInputs[key].checked = !!settings[key];
+    });
+    autoCloseSecs.value = settings.autoCloseSecs;
+    limitSlider.value = Math.min(settings.urlLimit, parseInt(limitSlider.max, 10));
+    limitNum.value = settings.urlLimit;
+    limitHint.textContent = settings.urlLimit === 0 ? 'No limit' : settings.urlLimit + ' max';
+    limitDesc.textContent = settings.urlLimit === 0
+      ? 'Open all URLs in the list'
+      : 'Open only the first ' + settings.urlLimit + ' URLs';
+  }
+
+  Object.keys(optionInputs).forEach(function(key) {
+    optionInputs[key].addEventListener('change', function() {
+      settings[key] = optionInputs[key].checked;
+      saveSettings();
+    });
+  });
+
+  autoCloseSecs.addEventListener('change', function() {
+    var v = parseInt(autoCloseSecs.value, 10);
+    settings.autoCloseSecs = (isNaN(v) || v < 1) ? 1 : v;
+    renderSettings();
+    saveSettings();
+  });
+
+  function setBatchSize(v) {
+    v = parseInt(v, 10);
+    if (isNaN(v)) v = 1;
+    settings.batchSize = Math.min(20, Math.max(1, v));
+    renderSettings();
+    saveSettings();
+  }
+
+  function setDelay(v) {
+    v = parseFloat(v);
+    if (isNaN(v) || v < 0) v = 0;
+    settings.delay = Math.min(100, v);
+    renderSettings();
+    saveSettings();
+  }
+
+  function setLimit(v) {
+    v = parseInt(v, 10);
+    if (isNaN(v) || v < 0) v = 0;
+    settings.urlLimit = v;
+    renderSettings();
+    saveSettings();
+  }
+
+  batchSlider.addEventListener('input', function() { setBatchSize(batchSlider.value); });
+  batchNum.addEventListener('change', function() { setBatchSize(batchNum.value); });
+  delaySlider.addEventListener('input', function() { setDelay(delaySlider.value); });
+  delayNum.addEventListener('change', function() { setDelay(delayNum.value); });
+  limitSlider.addEventListener('input', function() { setLimit(limitSlider.value); });
+  limitNum.addEventListener('change', function() { setLimit(limitNum.value); });
+
+  // Stepper − / + buttons next to the batch and delay sliders
+  document.querySelectorAll('.stepper-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var step = parseInt(btn.dataset.step, 10);
+      if (btn.dataset.for === 'batchSize') setBatchSize(settings.batchSize + step);
+      else setDelay(settings.delay + step);
+    });
+  });
+
+  document.getElementById('resetDefaults').addEventListener('click', function() {
+    settings = Object.assign({}, DEFAULT_SETTINGS);
+    renderSettings();
+    saveSettings();
+  });
+
+  // ------- Tab bar -------
+
+  function activateTab(name) {
+    document.querySelectorAll('.tab').forEach(function(t) {
+      t.classList.toggle('active', t.dataset.tab === name);
+    });
+    document.getElementById('panel-urls').classList.toggle('active', name === 'urls');
+    document.getElementById('panel-settings').classList.toggle('active', name === 'settings');
+  }
+
+  document.querySelectorAll('.tab').forEach(function(t) {
+    t.addEventListener('click', function() { activateTab(t.dataset.tab); });
+  });
+
+  document.getElementById('backToURLs').addEventListener('click', function() {
+    activateTab('urls');
+  });
+
+  // ------- Sidebar / new-tab launchers -------
+
+  var openSidebarBtn = document.getElementById('openSidebar');
+  if (isSidePanel) {
+    openSidebarBtn.hidden = true;
+  } else {
+    openSidebarBtn.addEventListener('click', function() {
+      chrome.windows.getCurrent(function(win) {
+        chrome.sidePanel.open({ windowId: win.id }, function() {
+          void chrome.runtime.lastError;
+          window.close();
+        });
+      });
+    });
+  }
+
+  document.getElementById('openInTab').addEventListener('click', function() {
+    chrome.tabs.create({ url: chrome.runtime.getURL('sidepanel.html') });
+  });
 
   // ------- Badge + count sync -------
 
@@ -14,7 +180,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
   function updateBadge() {
     var count = countURLs(userInput.value);
-    urlCount.textContent = count === 0 ? 'No URLs' : count + ' URL' + (count === 1 ? '' : 's');
+    urlCount.textContent = count + ' valid';
+    urlCount.classList.toggle('valid', count > 0);
     if (count === 0) {
       chrome.action.setBadgeText({ text: '' });
     } else {
@@ -23,21 +190,71 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 
-  // Every programmatic textarea write goes through here to keep badge in sync
+  // ------- Undo / redo history -------
+
+  var history = [userInput.value];
+  var historyIndex = 0;
+  var historyTimer = null;
+
+  function updateHistoryButtons() {
+    undoBtn.disabled = historyIndex === 0;
+    redoBtn.disabled = historyIndex === history.length - 1;
+  }
+
+  function pushHistory(value) {
+    if (history[historyIndex] === value) return;
+    history = history.slice(0, historyIndex + 1);
+    history.push(value);
+    if (history.length > 100) history.shift();
+    historyIndex = history.length - 1;
+    updateHistoryButtons();
+  }
+
+  undoBtn.addEventListener('click', function() {
+    if (historyIndex === 0) return;
+    historyIndex--;
+    userInput.value = history[historyIndex];
+    updateHistoryButtons();
+    updateBadge();
+  });
+
+  redoBtn.addEventListener('click', function() {
+    if (historyIndex === history.length - 1) return;
+    historyIndex++;
+    userInput.value = history[historyIndex];
+    updateHistoryButtons();
+    updateBadge();
+  });
+
+  // Every programmatic textarea write goes through here to keep badge + history in sync
   function setTextarea(value) {
     userInput.value = value;
+    pushHistory(value);
     updateBadge();
   }
 
-  // Sync badge on direct user edits (typing, paste, cut)
-  userInput.addEventListener('input', updateBadge);
+  // Sync badge on direct user edits (typing, paste, cut); snapshot history after a pause
+  userInput.addEventListener('input', function() {
+    updateBadge();
+    clearTimeout(historyTimer);
+    historyTimer = setTimeout(function() { pushHistory(userInput.value); }, 500);
+  });
+
+  updateHistoryButtons();
 
   // ------- Init -------
 
   // If a CSV import result is waiting in storage, consume it first.
   // Otherwise auto-populate from the page's current drag selection.
-  chrome.storage.local.get(['csv_import_result', 'popup_delay'], function(stored) {
-    if (stored.popup_delay) delayInput.value = stored.popup_delay;
+  chrome.storage.local.get(['csv_import_result', 'opener_settings', 'popup_delay'], function(stored) {
+    if (stored.opener_settings) {
+      settings = Object.assign({}, DEFAULT_SETTINGS, stored.opener_settings);
+    } else if (stored.popup_delay) {
+      // migrate the pre-0.4 delay setting
+      var d = parseFloat(stored.popup_delay);
+      if (!isNaN(d) && d > 0) settings.delay = d;
+    }
+    renderSettings();
     if (stored.csv_import_result) {
       setTextarea(stored.csv_import_result);
       chrome.storage.local.remove('csv_import_result');
@@ -63,47 +280,98 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 
-  delayInput.addEventListener('change', function() {
-    chrome.storage.local.set({ popup_delay: delayInput.value });
-  });
-
   // ------- Opening -------
 
-  function currentDelay() {
-    var d = parseFloat(delayInput.value);
-    return (isNaN(d) || d < 0) ? 0 : d;
+  // Turn the textarea into the list of URLs that would actually open.
+  // With "search queries" on, every non-empty line counts (non-URLs become searches).
+  function collectURLs() {
+    if (settings.searchQueries) {
+      return textToLines(userInput.value).map(function(line) {
+        var extracted = textToLines(extractURLs(line));
+        if (extracted.length > 0) return normalizeURL(extracted[0]);
+        return 'https://www.google.com/search?q=' + encodeURIComponent(line);
+      });
+    }
+    return textToLines(extractURLs(userInput.value)).map(normalizeURL);
   }
 
-  // Delegate to the background service worker so delayed opening
+  // Delegate to the background service worker so batched/delayed opening
   // continues even after the popup closes.
   function openURLs(mode) {
-    var urls = textToLines(extractURLs(userInput.value)).map(normalizeURL);
+    var urls = collectURLs();
     if (urls.length === 0) return;
+    var limited = settings.urlLimit > 0 ? urls.slice(0, settings.urlLimit) : urls;
     chrome.runtime.sendMessage({
       message: 'open_urls',
       urls: urls,
       mode: mode,
-      delay: currentDelay()
+      options: settings
     });
+    if (settings.removeOpened) {
+      var opened = {};
+      limited.forEach(function(u) { opened[u] = true; });
+      var remaining = textToLines(userInput.value).filter(function(line) {
+        var extracted = textToLines(extractURLs(line));
+        var asURL = extracted.length > 0 ? normalizeURL(extracted[0])
+          : (settings.searchQueries ? 'https://www.google.com/search?q=' + encodeURIComponent(line) : null);
+        return !(asURL && opened[asURL]);
+      });
+      setTextarea(remaining.join('\n'));
+    }
   }
 
   // ------- Saved lists -------
 
-  function refreshSavedLists(selectName) {
+  function refreshSavedLists(highlightName) {
     chrome.storage.local.get(['saved_lists'], function(stored) {
       var lists = stored.saved_lists || {};
-      savedLists.innerHTML = '';
-      var placeholder = document.createElement('option');
-      placeholder.value = '';
-      placeholder.textContent = 'Load a saved list…';
-      savedLists.appendChild(placeholder);
-      Object.keys(lists).sort().forEach(function(name) {
-        var opt = document.createElement('option');
-        opt.value = name;
-        opt.textContent = name;
-        savedLists.appendChild(opt);
+      var names = Object.keys(lists).sort();
+      savedListsContainer.innerHTML = '';
+      if (names.length === 0) {
+        var note = document.createElement('p');
+        note.className = 'empty-note';
+        note.textContent = 'No saved lists yet';
+        savedListsContainer.appendChild(note);
+        return;
+      }
+      names.forEach(function(name) {
+        var row = document.createElement('div');
+        row.className = 'saved-list-row';
+
+        var load = document.createElement('button');
+        load.className = 'saved-list-name';
+        load.textContent = name;
+        load.title = 'Load "' + name + '"';
+        load.addEventListener('click', function() {
+          setTextarea(lists[name]);
+          setListStatus('Loaded "' + name + '"');
+        });
+
+        var count = document.createElement('span');
+        count.className = 'saved-list-count';
+        count.textContent = countURLs(lists[name]) + ' URLs';
+
+        var del = document.createElement('button');
+        del.className = 'saved-list-delete';
+        del.textContent = '×';
+        del.title = 'Delete "' + name + '"';
+        del.addEventListener('click', function() {
+          chrome.storage.local.get(['saved_lists'], function(s) {
+            var l = s.saved_lists || {};
+            delete l[name];
+            chrome.storage.local.set({ saved_lists: l }, function() {
+              refreshSavedLists();
+              setListStatus('Deleted "' + name + '"');
+            });
+          });
+        });
+
+        row.appendChild(load);
+        row.appendChild(count);
+        row.appendChild(del);
+        savedListsContainer.appendChild(row);
       });
-      if (selectName) savedLists.value = selectName;
+      if (highlightName) setListStatus('Saved "' + highlightName + '"');
     });
   }
 
@@ -112,8 +380,14 @@ document.addEventListener('DOMContentLoaded', function() {
     setTimeout(function() { listStatus.textContent = ''; }, 2000);
   }
 
+  document.getElementById('newListToggle').addEventListener('click', function() {
+    var row = document.getElementById('newListRow');
+    row.hidden = !row.hidden;
+    if (!row.hidden) listName.focus();
+  });
+
   document.getElementById('saveList').addEventListener('click', function() {
-    var name = listName.value.trim() || savedLists.value;
+    var name = listName.value.trim();
     if (!name) {
       setListStatus('Enter a list name first');
       return;
@@ -127,32 +401,23 @@ document.addEventListener('DOMContentLoaded', function() {
       lists[name] = userInput.value;
       chrome.storage.local.set({ saved_lists: lists }, function() {
         listName.value = '';
+        document.getElementById('newListRow').hidden = true;
         refreshSavedLists(name);
-        setListStatus('Saved "' + name + '"');
       });
     });
   });
 
-  document.getElementById('deleteList').addEventListener('click', function() {
-    var name = savedLists.value;
-    if (!name) return;
-    chrome.storage.local.get(['saved_lists'], function(stored) {
-      var lists = stored.saved_lists || {};
-      delete lists[name];
-      chrome.storage.local.set({ saved_lists: lists }, function() {
-        refreshSavedLists();
-        setListStatus('Deleted "' + name + '"');
-      });
-    });
+  // ------- Tools dropdown -------
+
+  document.getElementById('toolsToggle').addEventListener('click', function(e) {
+    e.stopPropagation();
+    toolsMenu.hidden = !toolsMenu.hidden;
   });
 
-  savedLists.addEventListener('change', function() {
-    var name = savedLists.value;
-    if (!name) return;
-    chrome.storage.local.get(['saved_lists'], function(stored) {
-      var lists = stored.saved_lists || {};
-      if (lists[name] !== undefined) setTextarea(lists[name]);
-    });
+  document.addEventListener('click', function(e) {
+    if (!toolsMenu.hidden && !toolsMenu.contains(e.target)) {
+      toolsMenu.hidden = true;
+    }
   });
 
   // ------- Button handlers -------
@@ -164,6 +429,13 @@ document.addEventListener('DOMContentLoaded', function() {
         break;
       case "dedupeURLs":
         setTextarea(dedupeLines(textToLines(userInput.value)).join('\n'));
+        break;
+      case "copyURLs":
+        if (userInput.value) {
+          navigator.clipboard.writeText(userInput.value).then(function() {
+            setListStatus('Copied to clipboard');
+          });
+        }
         break;
       case "openURLsInTabs":
         openURLs('tabs');
@@ -188,11 +460,13 @@ document.addEventListener('DOMContentLoaded', function() {
         openImportWindow();
         break;
     }
-    userClick.preventDefault();
+    if (userClick.target.classList && userClick.target.classList.contains('tools-item')) {
+      toolsMenu.hidden = true;
+    }
   });
 
-  // "Selection Tool URLs" — manually refresh from the current drag selection
-  document.getElementById('openURLsFromSelector').onclick = function() {
+  // "URLs from Selection" — manually refresh from the current drag selection
+  document.getElementById('openURLsFromSelector').addEventListener('click', function() {
     chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
       if (!tabs || !tabs[0]) return;
       chrome.tabs.sendMessage(tabs[0].id, { type: "getURLs" }, function(response) {
@@ -201,7 +475,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (text) setTextarea(text);
       });
     });
-  };
+  });
 
   // ------- Helpers scoped to DOMContentLoaded -------
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,18 @@
 {
   "name": "BulkyURLs",
   "description": "Manage a large number of URLs without having to go back-and-forth between the browser.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "manifest_version": 3,
   "permissions": [
     "activeTab",
     "tabs",
     "storage",
-    "contextMenus"
+    "contextMenus",
+    "sidePanel"
   ],
+  "side_panel": {
+    "default_path": "sidepanel.html"
+  },
   "host_permissions": [
     "http://*/*",
     "https://*/*"

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="css/popup.css">
 </head>
 
-<body>
+<body class="sidepanel">
   <header class="app-header">
     <h1><img src="img/bulkyurls-icon-32x32.png" alt=""> BulkyURLs</h1>
     <span class="app-version" id="appVersion"></span>


### PR DESCRIPTION
## Summary

Rebuilds the popup around the feature set researched in `research/` (competitor: Bulk URL Opener & Tab Manager), styled with our existing design tokens, and adds the side-tab feature.

- **Side panel** — new `sidepanel.html` (same UI, fluid width) registered via the `sidePanel` API; popup gains **Open Sidebar** / **Open in New Tab** launchers
- **Tabbed popup** — reorganized into **URLs** and **Settings** tabs with a card layout and a live "N valid" count badge
- **Batch opening** — URLs per batch (1–20) and delay between batches (0–100s) with sliders/steppers; opening runs in the background service worker so it survives popup close
- **URL editor** — undo/redo history, Copy, Extract URLs, Clear, and a **Tools ▾** dropdown (URLs from Tabs / from Selection, Remove Duplicates, CSV import/export)
- **New opener settings** — convert non-URLs to search queries, random/reverse order, window per batch, wait-for-load, remove opened from input, auto-close after N seconds, URL limit, reset defaults; persisted under `opener_settings`
- **Saved lists redesign** — rows with URL counts, click-to-load, inline delete, "+ New" save form
- Migrates the pre-0.4 `popup_delay` setting; bumps manifest to 0.4.0; updates README and CHANGELOG

## Testing

- `node --check` on all changed JS; manifest JSON validated
- Both tabs, saved-lists rows, and the narrow side-panel layout verified visually in headless Chrome with a stubbed `chrome` API
- Not yet exercised in a live browser: `sidePanel.open()` and the batch-opening paths — worth a quick manual pass via Load unpacked before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)