### PR TITLE
Fix: drag-select/right-click links don't reach an already-open panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to BulkyURLs will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-07-22
+
+### Fixed
+- **Drag-select and "Add link to BulkyURLs" did nothing while the panel was already open** — the content script only wrote new selections to its own memory and a storage key read by the toolbar badge; nothing told an already-open side panel about them, so they only showed up after closing and reopening it. The content script now also broadcasts the update, and the panel applies it when it's showing the tab the selection came from
+
 ## [0.7.0] - 2026-07-22
 
 ### Fixed

--- a/js/content/content-script.js
+++ b/js/content/content-script.js
@@ -573,6 +573,13 @@ function send_message(linkArray) {
 	} catch (e) {
 		// Orphaned content script — nothing to do
 	}
+	// Notify an already-open side panel/tab so a live selection shows up without
+	// having to close and reopen it. No-op if nothing is listening.
+	try {
+		chrome.runtime.sendMessage({ type: "urlsUpdated", urls: linkArray });
+	} catch (e) {
+		// Orphaned content script — nothing to do
+	}
 }
 
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -702,6 +702,20 @@ document.addEventListener('DOMContentLoaded', function() {
 
   refreshSavedLists();
 
+  // The side panel stays open while browsing, so a drag-select or right-click
+  // "Add link" on the page needs to reach an already-open panel — otherwise
+  // it silently lands in the content script's memory until the panel is
+  // reopened. The content script broadcasts on every selection change; only
+  // act on it when it's coming from the tab currently in view.
+  chrome.runtime.onMessage.addListener(function(request, sender) {
+    if (request.type !== 'urlsUpdated' || !sender.tab) return;
+    chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+      if (!tabs || !tabs[0] || tabs[0].id !== sender.tab.id) return;
+      var text = urlsToText({ urls: request.urls });
+      if (text) setTextarea(text);
+    });
+  });
+
   // ------- Opening -------
 
   // Turn the textarea into the list of URLs that would actually open.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "BulkyURLs",
   "description": "Manage a large number of URLs without having to go back-and-forth between the browser.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "manifest_version": 3,
   "permissions": [
     "activeTab",


### PR DESCRIPTION
## Summary
- Root cause: the content script only wrote new selections (drag-select mouseup, right-click "Add link to BulkyURLs", "Copy visible page links") to its own in-memory `latestURLs` and to a storage key the toolbar badge listens for. Nothing notified an already-open side panel, so the textarea only ever picked up a selection when the panel was freshly opened (one-time fetch on load).
- This regressed in practice once the side panel became the persistent default surface (popup.html removed in v0.6.0) — staying open across selections is now the normal case, not the exception.
- Fix: `send_message()` in `js/content/content-script.js` now also broadcasts `{ type: "urlsUpdated", urls }` via `chrome.runtime.sendMessage`. `js/popup.js` listens for it and applies the update only when the message's sender tab matches the tab currently in view.
- Bumps `manifest.json` to 0.7.1.

Verified end-to-end with a Playwright driver against the built, unpacked extension (loaded in real Chrome, not just unit-level): opened the side panel first, then performed an actual drag-select over links on a test page — the panel's textarea updated live without closing/reopening it. Also simulated the right-click "Add link" context-menu path (by calling the same `chrome.tabs.sendMessage` the context-menu handler uses) and confirmed the same live update.

## Test plan
- [x] Drag-select links on a page while the panel is already open — textarea updates live (Playwright-verified)
- [x] Right-click → "Add link to BulkyURLs" while the panel is already open — textarea updates live (Playwright-verified, simulated context-menu click)
- [ ] Manual smoke test in real Chrome for the native right-click context menu UI itself